### PR TITLE
Add debug output for init steps

### DIFF
--- a/api/api0api.c
+++ b/api/api0api.c
@@ -728,12 +728,16 @@ ib_init(void)
 {
 	ib_err_t	ib_err;
 
+	fprintf(stderr, "ib_init: start\n");
+
 	ut_mem_init();
+	fprintf(stderr, "ib_init: memory subsystem initialized\n");
 
 	ib_logger = (ib_logger_t) fprintf;
 	ib_stream = stderr;
 
 	ib_err = ib_cfg_init();
+	fprintf(stderr, "ib_init: ib_cfg_init returned %d\n", ib_err);
 
 	return(ib_err);
 }

--- a/api/api0cfg.c
+++ b/api/api0cfg.c
@@ -1282,8 +1282,9 @@ ib_err_t
 ib_cfg_init(void)
 /*=============*/
 {
-	/* Initialize the mutex that protects cfg_vars[]. */
-	os_fast_mutex_init(&cfg_vars_mutex);
+       fprintf(stderr, "ib_cfg_init: start\n");
+       /* Initialize the mutex that protects cfg_vars[]. */
+       os_fast_mutex_init(&cfg_vars_mutex);
 
 	ut_memcpy(cfg_vars, cfg_vars_defaults, sizeof(cfg_vars));
 
@@ -1316,10 +1317,12 @@ ib_cfg_init(void)
 	IB_CFG_SET("lru_block_access_recency", 0);
 	IB_CFG_SET("rollback_on_timeout", IB_TRUE);
 	IB_CFG_SET("read_io_threads", 4);
-	IB_CFG_SET("write_io_threads", 4);
+       IB_CFG_SET("write_io_threads", 4);
 #undef IB_CFG_SET
 
-	return(DB_SUCCESS);
+       fprintf(stderr, "ib_cfg_init: configuration defaults set\n");
+
+       return(DB_SUCCESS);
 }
 /* @} */
 

--- a/srv/srv0start.c
+++ b/srv/srv0start.c
@@ -1174,6 +1174,7 @@ ib_err_t
 innobase_start_or_create(void)
 /*===========================*/
 {
+	ib_logger(ib_stream, "innobase_start_or_create: begin\n");
 	buf_pool_t*	ret;
 	ibool		create_new_db;
 	ibool		log_file_created;

--- a/tests/ib_cursor.c
+++ b/tests/ib_cursor.c
@@ -294,31 +294,39 @@ int main(int argc, char* argv[])
 	ib_trx_t	ib_trx;
 	ib_tpl_t	tpl = NULL;
 
-	err = ib_init();
-	assert(err == DB_SUCCESS);
+        printf("Calling ib_init()\n");
+        err = ib_init();
+        assert(err == DB_SUCCESS);
 
-	test_configure();
+        test_configure();
 
-	err = ib_startup("barracuda");
-	assert(err == DB_SUCCESS);
+        printf("Calling ib_startup()\n");
+        err = ib_startup("barracuda");
+        assert(err == DB_SUCCESS);
 
-	err = create_database(DATABASE);
-	assert(err == DB_SUCCESS);
+        printf("Calling create_database()\n");
+        err = create_database(DATABASE);
+        assert(err == DB_SUCCESS);
 
-	err = create_table(DATABASE, TABLE);
-	assert(err == DB_SUCCESS);
+        printf("Calling create_table()\n");
+        err = create_table(DATABASE, TABLE);
+        assert(err == DB_SUCCESS);
 
-	ib_trx = ib_trx_begin(IB_TRX_REPEATABLE_READ);
-	assert(ib_trx != NULL);
+        printf("Starting transaction\n");
+        ib_trx = ib_trx_begin(IB_TRX_REPEATABLE_READ);
+        assert(ib_trx != NULL);
 
-	err = open_table(DATABASE, TABLE, ib_trx, &crsr);
-	assert(err == DB_SUCCESS);
+        printf("Opening table\n");
+        err = open_table(DATABASE, TABLE, ib_trx, &crsr);
+        assert(err == DB_SUCCESS);
 
-	err = ib_cursor_lock(crsr, IB_LOCK_IX);
-	assert(err == DB_SUCCESS);
+        printf("Locking cursor\n");
+        err = ib_cursor_lock(crsr, IB_LOCK_IX);
+        assert(err == DB_SUCCESS);
 
-	err = insert_rows(crsr);
-	assert(err == DB_SUCCESS);
+        printf("Inserting rows\n");
+        err = insert_rows(crsr);
+        assert(err == DB_SUCCESS);
 
 	/*==========================================*/
 	printf("SELECT * FROM T;\n");


### PR DESCRIPTION
## Summary
- emit debug logs during `ib_init()`
- show startup of configuration via `ib_cfg_init()`
- log entry when InnoDB engine starts up

## Testing
- `make -C tests ib_cursor`
- `LD_LIBRARY_PATH=.libs tests/.libs/ib_cursor`

------
https://chatgpt.com/codex/tasks/task_e_6853ea4e2cf4832daab6111559473cec